### PR TITLE
Fix various triple battle bugs

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -13,7 +13,9 @@
 #include "battle_bg.h"
 #include "pokeball.h"
 
-#define IS_BATTLER_ABSENT(battler)        ((gAbsentBattlerFlags) & (gBitTable[battler]))
+#define IS_BATTLER_ABSENT(battler)            ((gAbsentBattlerFlags) & (gBitTable[battler]))
+#define IS_BATTLER_INVALID(battler)           ((!(gBattleTypeFlags & BATTLE_TYPE_TRIPLE) && ((!(gBattleTypeFlags & BATTLE_TYPE_DOUBLE) && battler >= 2) || (battler >= 4))))
+#define IS_BATTLER_INVALID_OR_ABSENT(battler) ((IS_BATTLER_INVALID(battler)) || (IS_BATTLER_ABSENT(battler)))
 
 #define GET_BATTLER_POSITION(battler)     (gBattlerPositions[battler])
 #define GET_BATTLER_SIDE(battler)         (GetBattlerPosition(battler) & BIT_SIDE)

--- a/include/battle.h
+++ b/include/battle.h
@@ -13,6 +13,8 @@
 #include "battle_bg.h"
 #include "pokeball.h"
 
+#define IS_BATTLER_ABSENT(battler)        ((gAbsentBattlerFlags) & (gBitTable[battler]))
+
 #define GET_BATTLER_POSITION(battler)     (gBattlerPositions[battler])
 #define GET_BATTLER_SIDE(battler)         (GetBattlerPosition(battler) & BIT_SIDE)
 #define GET_BATTLER_SIDE2(battler)        (GET_BATTLER_POSITION(battler) & BIT_SIDE)

--- a/include/battle_order.h
+++ b/include/battle_order.h
@@ -10,5 +10,6 @@ u8 GetBattlerWithLowestTicks(void);
 u32 CalculateAddedTicks(u8 battlerId, u8 moveSpeed);
 void CreateAllBattleOrderMonIconSprites(void);
 void UpdateBattleOrderMonIconSprites(void);
+void FreeBattleOrderMonIconSprites(void);
 
 #endif // GUARD_BATTLE_ORDER_H

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -577,14 +577,15 @@ static void OpponentBufferExecCompleted(void)
 
 static void OpponentHandleGetMonData(void)
 {
-    u8 monData[sizeof(struct Pokemon) * 2 + 56]; // this allows to get full data of two pokemon, trying to get more will result in overwriting data
+    u8 monData[sizeof(struct Pokemon) * 3 + 56]; // this allows to get full data of three pokemon, trying to get more will result in overwriting data
     u32 size = 0;
     u8 monToCheck;
     s32 i;
 
     if (gBattleBufferA[gActiveBattler][2] == 0)
     {
-        size += GetOpponentMonData(gBattlerPartyIndexes[gActiveBattler], monData);
+        if (gBattlerPartyIndexes[gActiveBattler] != PARTY_SIZE)
+            size += GetOpponentMonData(gBattlerPartyIndexes[gActiveBattler], monData);
     }
     else
     {

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -985,11 +985,10 @@ static void Intro_WaitForShinyAnimAndHealthbox(void)
             healthboxAnimDone = TRUE;
     }
 
-    CreateAllBattleOrderMonIconSprites();
-
     // If healthbox and shiny anim are done
     if (healthboxAnimDone && FinishedAllShinyMonAnims())
     {
+        CreateAllBattleOrderMonIconSprites();
         ResetShinyAnims();
         gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].introEndDelay = 3;
         gBattlerControllerFuncs[gActiveBattler] = Intro_DelayAndEnd;

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -934,7 +934,7 @@ static bool8 FinishedAllShinyMonAnims(void)
     u8 battler = gActiveBattler;
     for (i = 0; i < MAX_BATTLERS_COUNT / 2; i++)
     {
-        if (!IS_BATTLER_ABSENT(battler) && !gBattleSpritesDataPtr->healthBoxesData[battler].finishedShinyMonAnim)
+        if (!IS_BATTLER_INVALID_OR_ABSENT(battler) && !gBattleSpritesDataPtr->healthBoxesData[battler].finishedShinyMonAnim)
             return FALSE;
         battler = BATTLER_TO_RIGHT(battler);
     }
@@ -952,7 +952,7 @@ static void ResetShinyAnims() {
         gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].triedShinyMonAnim = FALSE;
         gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].finishedShinyMonAnim = FALSE;
 
-        if (!IS_BATTLER_ABSENT(gActiveBattler))
+        if (!IS_BATTLER_INVALID_OR_ABSENT(gActiveBattler))
         {
             HandleLowHpMusicChange(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], gActiveBattler);
         }
@@ -1017,7 +1017,7 @@ static void Intro_TryShinyAnimShowHealthbox(void)
 
     for (i = 0; i < MAX_BATTLERS_COUNT / 2; i++)
     {
-        if (!IS_BATTLER_ABSENT(gActiveBattler))
+        if (!IS_BATTLER_INVALID_OR_ABSENT(gActiveBattler))
         {
             TryShinyAnimationHelper(gActiveBattler);
         }
@@ -1033,7 +1033,7 @@ static void Intro_TryShinyAnimShowHealthbox(void)
         {
             for (i = 0; i < MAX_BATTLERS_COUNT / 2; i++)
             {
-                if (!IS_BATTLER_ABSENT(gActiveBattler))
+                if (!IS_BATTLER_INVALID_OR_ABSENT(gActiveBattler))
                 {
                     StartHealthboxSlideInHelper(gActiveBattler);
                 }
@@ -1098,7 +1098,7 @@ static void Intro_TryShinyAnimShowHealthbox(void)
     {
         for (i = 0; i < MAX_BATTLERS_COUNT / 2; i++)
         {
-            if (!IS_BATTLER_ABSENT(gActiveBattler))
+            if (!IS_BATTLER_INVALID_OR_ABSENT(gActiveBattler))
             {
                 DestroySprite(&gSprites[gBattleControllerData[gActiveBattler]]);
             }
@@ -3081,7 +3081,7 @@ static void Task_StartSendOutAnim(u8 taskId)
         {
             for (i = 0; i < MAX_BATTLERS_COUNT / 2; i++)
             {
-                if (!IS_BATTLER_ABSENT(gActiveBattler))
+                if (!IS_BATTLER_INVALID_OR_ABSENT(gActiveBattler))
                 {
                     gBattleBufferA[gActiveBattler][1] = gBattlerPartyIndexes[gActiveBattler];
                     BattleLoadPlayerMonSpriteGfx(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], gActiveBattler);

--- a/src/battle_controller_wally.c
+++ b/src/battle_controller_wally.c
@@ -4,6 +4,7 @@
 #include "battle_controllers.h"
 #include "battle_interface.h"
 #include "battle_message.h"
+#include "battle_order.h"
 #include "battle_setup.h"
 #include "battle_tv.h"
 #include "bg.h"
@@ -326,6 +327,8 @@ static void Intro_WaitForShinyAnimAndHealthbox(void)
     if (healthboxAnimDone && gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].finishedShinyMonAnim
         && gBattleSpritesDataPtr->healthBoxesData[gActiveBattler ^ BIT_FLANK].finishedShinyMonAnim)
     {
+        CreateAllBattleOrderMonIconSprites();
+
         gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].triedShinyMonAnim = FALSE;
         gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].finishedShinyMonAnim = FALSE;
 

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -602,73 +602,71 @@ static void InitLinkBtlControllers(void)
     }
 }
 
+static s32 GetBattlePartyIndex(s32 i, bool8 include_fainted)
+{
+    s32 j;
+    for (j = 0; j < PARTY_SIZE; j++)
+    {
+        if (i < 2)
+        {
+            if (GET_BATTLER_SIDE2(i) == B_SIDE_PLAYER)
+            {
+                if ((include_fainted || GetMonData(&gPlayerParty[j], MON_DATA_HP) != 0)
+                    && GetMonData(&gPlayerParty[j], MON_DATA_SPECIES2) != SPECIES_NONE
+                    && GetMonData(&gPlayerParty[j], MON_DATA_SPECIES2) != SPECIES_EGG
+                    && GetMonData(&gPlayerParty[j], MON_DATA_IS_EGG) == 0)
+                    return j;
+            }
+            else
+            {
+                if ((include_fainted || GetMonData(&gEnemyParty[j], MON_DATA_HP) != 0)
+                    && GetMonData(&gEnemyParty[j], MON_DATA_SPECIES2) != SPECIES_NONE
+                    && GetMonData(&gEnemyParty[j], MON_DATA_SPECIES2) != SPECIES_EGG
+                    && GetMonData(&gEnemyParty[j], MON_DATA_IS_EGG) == 0)
+                    return j;
+            }
+        }
+        else
+        {
+            if (GET_BATTLER_SIDE2(i) == B_SIDE_PLAYER)
+            {
+                if ((include_fainted || GetMonData(&gPlayerParty[j], MON_DATA_HP) != 0)
+                    && GetMonData(&gPlayerParty[j], MON_DATA_SPECIES2) != SPECIES_NONE
+                    && GetMonData(&gPlayerParty[j], MON_DATA_SPECIES2) != SPECIES_EGG
+                    && GetMonData(&gPlayerParty[j], MON_DATA_IS_EGG) == 0
+                    && gBattlerPartyIndexes[i - 2] != j
+                    && (i < 4 || gBattlerPartyIndexes[i - 4] != j) // for triple battle
+                )
+                    return j;
+            }
+            else
+            {
+                if ((include_fainted || GetMonData(&gEnemyParty[j], MON_DATA_HP) != 0)
+                    && GetMonData(&gEnemyParty[j], MON_DATA_SPECIES2) != SPECIES_NONE
+                    && GetMonData(&gEnemyParty[j], MON_DATA_SPECIES2) != SPECIES_EGG
+                    && GetMonData(&gEnemyParty[j], MON_DATA_IS_EGG) == 0
+                    && gBattlerPartyIndexes[i - 2] != j
+                    && (i < 4 || gBattlerPartyIndexes[i - 4] != j) // for triple battle
+                )
+                    return j;
+            }
+        }
+    }
+    return PARTY_SIZE;
+}
+
 static void SetBattlePartyIds(void)
 {
-    s32 i, j;
+    s32 i, res;
 
     if (!(gBattleTypeFlags & BATTLE_TYPE_MULTI))
     {
         for (i = 0; i < gBattlersCount; i++)
         {
-            for (j = 0; j < PARTY_SIZE; j++)
-            {
-                if (i < 2)
-                {
-                    if (GET_BATTLER_SIDE2(i) == B_SIDE_PLAYER)
-                    {
-                        if (GetMonData(&gPlayerParty[j], MON_DATA_HP) != 0
-                         && GetMonData(&gPlayerParty[j], MON_DATA_SPECIES2) != SPECIES_NONE
-                         && GetMonData(&gPlayerParty[j], MON_DATA_SPECIES2) != SPECIES_EGG
-                         && GetMonData(&gPlayerParty[j], MON_DATA_IS_EGG) == 0)
-                        {
-                            gBattlerPartyIndexes[i] = j;
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        if (GetMonData(&gEnemyParty[j], MON_DATA_HP) != 0
-                         && GetMonData(&gEnemyParty[j], MON_DATA_SPECIES2) != SPECIES_NONE
-                         && GetMonData(&gEnemyParty[j], MON_DATA_SPECIES2) != SPECIES_EGG
-                         && GetMonData(&gEnemyParty[j], MON_DATA_IS_EGG) == 0)
-                        {
-                            gBattlerPartyIndexes[i] = j;
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    if (GET_BATTLER_SIDE2(i) == B_SIDE_PLAYER)
-                    {
-                        if (GetMonData(&gPlayerParty[j], MON_DATA_HP) != 0
-                         && GetMonData(&gPlayerParty[j], MON_DATA_SPECIES) != SPECIES_NONE  // Probably a typo by Game Freak. The rest use SPECIES2.
-                         && GetMonData(&gPlayerParty[j], MON_DATA_SPECIES2) != SPECIES_EGG
-                         && GetMonData(&gPlayerParty[j], MON_DATA_IS_EGG) == 0
-                         && gBattlerPartyIndexes[i - 2] != j
-                         && (i < 4 || gBattlerPartyIndexes[i - 4] != j) // for triple battle
-                        )
-                        {
-                            gBattlerPartyIndexes[i] = j;
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        if (GetMonData(&gEnemyParty[j], MON_DATA_HP) != 0
-                         && GetMonData(&gEnemyParty[j], MON_DATA_SPECIES2) != SPECIES_NONE
-                         && GetMonData(&gEnemyParty[j], MON_DATA_SPECIES2) != SPECIES_EGG
-                         && GetMonData(&gEnemyParty[j], MON_DATA_IS_EGG) == 0
-                         && gBattlerPartyIndexes[i - 2] != j
-                         && (i < 4 || gBattlerPartyIndexes[i - 4] != j) // for triple battle
-                        )
-                        {
-                            gBattlerPartyIndexes[i] = j;
-                            break;
-                        }
-                    }
-                }
-            }
+            res = GetBattlePartyIndex(i, FALSE);
+            if (res == PARTY_SIZE)
+                res = GetBattlePartyIndex(i, TRUE);
+            gBattlerPartyIndexes[i] = res;
         }
 
         if (gBattleTypeFlags & BATTLE_TYPE_TWO_OPPONENTS)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3481,7 +3481,7 @@ static void BattleIntroDrawTrainersOrMonsSprites(void)
             BattleArena_InitPoints();
     }
 
-    for (gActiveBattler = 0; gActiveBattler < MAX_BATTLERS_COUNT; gActiveBattler++)
+    for (gActiveBattler = 0; gActiveBattler < gBattlersCount; gActiveBattler++)
     {
         if (gBattleMons[gActiveBattler].hp == 0
             || gBattlerPartyIndexes[gActiveBattler] == PARTY_SIZE)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5078,6 +5078,7 @@ static void FreeResetData_ReturnToOvOrDoEvolutions(void)
     }
 
     FreeAllWindowBuffers();
+    FreeBattleOrderMonIconSprites();
     if (!(gBattleTypeFlags & BATTLE_TYPE_LINK))
     {
         FreeMonSpritesGfx();

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -3480,6 +3480,17 @@ static void BattleIntroDrawTrainersOrMonsSprites(void)
         if (gBattleTypeFlags & BATTLE_TYPE_ARENA)
             BattleArena_InitPoints();
     }
+
+    for (gActiveBattler = 0; gActiveBattler < MAX_BATTLERS_COUNT; gActiveBattler++)
+    {
+        if (gBattleMons[gActiveBattler].hp == 0
+            || gBattlerPartyIndexes[gActiveBattler] == PARTY_SIZE)
+        {
+            FaintClearSetData();
+            gAbsentBattlerFlags |= gBitTable[gActiveBattler];
+        }
+    }
+
     gBattleMainFunc = BattleIntroDrawPartySummaryScreens;
 }
 

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -2064,7 +2064,7 @@ static u8 * GetBattlerSendoutStringPtr(bool8 isPlayer)
     u8 numBattlers = 0;
     for (i = 0; i < MAX_BATTLERS_COUNT / 2; i++)
     {
-        if (!IS_BATTLER_ABSENT(gActiveBattler))
+        if (!IS_BATTLER_INVALID_OR_ABSENT(gActiveBattler))
             numBattlers++;
         gActiveBattler = BATTLER_TO_RIGHT(gActiveBattler);
     }

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -19,6 +19,7 @@
 #include "strings.h"
 #include "text.h"
 #include "trainer_hill.h"
+#include "util.h"
 #include "window.h"
 #include "constants/battle_dome.h"
 #include "constants/battle_string_ids.h"
@@ -397,6 +398,7 @@ static const u8 sText_LinkTrainerMultiSentOutPkmn[] = _("{B_LINK_SCR_TRAINER_NAM
 static const u8 sText_GoPkmn[] = _("Go! {B_PLAYER_MON1_NAME}!");
 static const u8 sText_GoTwoPkmn[] = _("Go! {B_PLAYER_MON1_NAME} and\n{B_PLAYER_MON2_NAME}!");
 static const u8 sText_GoThreePkmn[] = _("Go! {B_PLAYER_MON1_NAME}, {B_PLAYER_MON2_NAME} and\n{B_PLAYER_MON3_NAME}!");
+static const u8 sText_GoError[] = _("Yikes, an error occurred");
 static const u8 sText_GoPkmn2[] = _("Go! {B_BUFF1}!");
 static const u8 sText_DoItPkmn[] = _("Do it! {B_BUFF1}!");
 static const u8 sText_GoForItPkmn[] = _("Go for it, {B_BUFF1}!");
@@ -2056,6 +2058,35 @@ static const struct BattleWindowText *const sBattleTextOnWindowsInfo[] =
 
 static const u8 sRecordedBattleTextSpeeds[] = {8, 4, 1, 0};
 
+static u8 * GetBattlerSendoutStringPtr(bool8 isPlayer)
+{
+    u8 i;
+    u8 numBattlers = 0;
+    for (i = 0; i < MAX_BATTLERS_COUNT / 2; i++)
+    {
+        if (!IS_BATTLER_ABSENT(gActiveBattler))
+            numBattlers++;
+        gActiveBattler = BATTLER_TO_RIGHT(gActiveBattler);
+    }
+
+    if (numBattlers == 1)
+    {
+        if (isPlayer) return (u8*)sText_GoPkmn;
+        return (u8*)sText_Trainer1SentOutPkmn;
+    }
+    if (numBattlers == 2)
+    {
+        if (isPlayer) return (u8*)sText_GoTwoPkmn;
+        return (u8*)sText_Trainer1SentOutTwoPkmn;
+    }
+    if (numBattlers == 3)
+    {
+        if (isPlayer) return (u8*)sText_GoThreePkmn;
+        return (u8*)sText_Trainer1SentOutThreePkmn;
+    }
+    return (u8*)sText_GoError;
+}
+
 void BufferStringBattle(u16 stringID)
 {
     s32 i;
@@ -2143,11 +2174,11 @@ void BufferStringBattle(u16 stringID)
                 else if (gBattleTypeFlags & BATTLE_TYPE_MULTI)
                     stringPtr = sText_LinkPartnerSentOutPkmnGoPkmn;
                 else
-                    stringPtr = sText_GoTwoPkmn;
+                    stringPtr = GetBattlerSendoutStringPtr(TRUE);
             }
             else if (gBattleTypeFlags & BATTLE_TYPE_TRIPLE)
             {
-                stringPtr = sText_GoThreePkmn;
+                stringPtr = GetBattlerSendoutStringPtr(TRUE);
             }
             else
             {
@@ -2167,11 +2198,11 @@ void BufferStringBattle(u16 stringID)
                 else if (gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_RECORDED_LINK))
                     stringPtr = sText_LinkTrainerSentOutTwoPkmn;
                 else
-                    stringPtr = sText_Trainer1SentOutTwoPkmn;
+                    stringPtr = GetBattlerSendoutStringPtr(FALSE);
             }
             else if (gBattleTypeFlags & BATTLE_TYPE_TRIPLE)
             {
-                stringPtr = sText_Trainer1SentOutThreePkmn;
+                stringPtr = GetBattlerSendoutStringPtr(FALSE);
             }
             else
             {

--- a/src/battle_order.c
+++ b/src/battle_order.c
@@ -304,3 +304,16 @@ void UpdateBattleOrderMonIconSprites()
         gSpeciesTurnOrder[i] = getSpeciesData(gBattleMons[battlerId]);
     }
 }
+
+void FreeBattleOrderMonIconSprites()
+{
+    u8 i;
+
+    FreeMonIconPalettes();
+
+    for (i = 0; i < MAX_BATTLERS_ORDER_COUNT; i++)
+    {
+        FreeAndDestroyMonIconSprite(&gSprites[gSpriteTurnOrder[i]]);
+        FreeAndDestroyMonIconSprite(&gSprites[gBgTurnOrder[i]]);
+    }
+}

--- a/src/reshow_battle_screen.c
+++ b/src/reshow_battle_screen.c
@@ -249,7 +249,7 @@ static void CreateBattlerSprite(u8 battler)
 
         if (GetBattlerSide(battler) != B_SIDE_PLAYER)
         {
-            if (GetMonData(&gEnemyParty[gBattlerPartyIndexes[battler]], MON_DATA_HP) == 0)
+            if (gBattlerPartyIndexes[battler] == PARTY_SIZE || GetMonData(&gEnemyParty[gBattlerPartyIndexes[battler]], MON_DATA_HP) == 0)
                 return;
 
             SetMultiuseSpriteTemplateToPokemon(GetMonData(&gEnemyParty[gBattlerPartyIndexes[battler]], MON_DATA_SPECIES), GetBattlerPosition(battler));
@@ -285,7 +285,7 @@ static void CreateBattlerSprite(u8 battler)
         }
         else
         {
-            if (GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_HP) == 0)
+            if (gBattlerPartyIndexes[battler] == PARTY_SIZE || GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_HP) == 0)
                 return;
 
             SetMultiuseSpriteTemplateToPokemon(GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_SPECIES), GetBattlerPosition(battler));
@@ -335,12 +335,12 @@ static void CreateHealthboxSprite(u8 battler)
 
         if (GetBattlerSide(battler) != B_SIDE_PLAYER)
         {
-            if (GetMonData(&gEnemyParty[gBattlerPartyIndexes[battler]], MON_DATA_HP) == 0)
+            if (gBattlerPartyIndexes[battler] == PARTY_SIZE || GetMonData(&gEnemyParty[gBattlerPartyIndexes[battler]], MON_DATA_HP) == 0)
                 SetHealthboxSpriteInvisible(healthboxSpriteId);
         }
         else if (!(gBattleTypeFlags & BATTLE_TYPE_SAFARI))
         {
-            if (GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_HP) == 0)
+            if (gBattlerPartyIndexes[battler] == PARTY_SIZE || GetMonData(&gPlayerParty[gBattlerPartyIndexes[battler]], MON_DATA_HP) == 0)
                 SetHealthboxSpriteInvisible(healthboxSpriteId);
         }
     }


### PR DESCRIPTION
Bugs fixed:
- If battler starts with fewer than 3 pokemon in a triple battle, then it would actually send out an invalid pokemon in the last slot
- Fix battle order icons for wally battle
- Fix bug where reshowing battle screen when there are fewer than 3 pokemon would result in showing a third pokemon
- Fix bug where mon icons are not being cleaned up properly after battle ends (display would be glitchy in future battles)
- Fix bug where pokemon movesets would don't change when they level up
- Fix bug where game freezes when a pokemon gains exp